### PR TITLE
Fix/200488 notification open

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,17 +10,18 @@
 
 Bump versions in:
 
--   [ ] `CHANGELOG.md`
--   [ ] `pubspec.yaml` 
--   [ ] `example/pubspec.yaml`
--   [ ] `ios/optimove_flutter.podspec` 
--   [ ] `ios/Classes/SwiftOptimoveFlutterPlugin.swift` 
--   [ ] `android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java`
+- [ ] `CHANGELOG.md`
+- [ ] `pubspec.yaml` 
+- [ ] `example/pubspec.yaml`
+- [ ] `ios/optimove_flutter.podspec` 
+- [ ] `ios/Classes/SwiftOptimoveFlutterPlugin.swift` 
+- [ ] `android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java`
 
 Release:
 
--   [ ] Squash and merge to main
--   [ ] Delete branch once merged
--   [ ] Create tag from main matching chosen version
--   [ ] Fill out release notes
--   [ ] Run `flutter pub publish`
+- [ ] Squash and merge to main
+- [ ] Delete branch once merged
+- [ ] Create tag from main matching chosen version
+- [ ] Fill out release notes
+- [ ] Run `dart pub publish --dry-run` to make sure there are no issues
+- [ ] Run `dart pub publish`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.0
+
+- [Breaking] For push opens don't set launch intent flags. Instead rely on the default launch mode.
+- 
 ## 2.2.0
 
 - Updated the iOS SDK to version 5.2.2

--- a/android/src/main/java/com/optimove/flutter/JsonUtils.java
+++ b/android/src/main/java/com/optimove/flutter/JsonUtils.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 // Based on https://gist.github.com/codebutler/2339666
-/** package */ class JsonUtils {
+public class JsonUtils {
 
     public static Map<String, Object> toMap(JSONObject object) throws JSONException {
         Map<String, Object> map = new HashMap<>();

--- a/android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java
+++ b/android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java
@@ -42,7 +42,7 @@ public class OptimoveInitProvider extends ContentProvider {
     private static final String IN_APP_EXPLICIT_BY_USER_KEY = "explicit-by-user";
     private static final String ENABLE_DDL_KEY = "enableDeferredDeepLinking";
 
-    private static final String SDK_VERSION = "2.2.0";
+    private static final String SDK_VERSION = "3.0.0";
     private static final int SDK_TYPE = 105;
     private static final int RUNTIME_TYPE = 9;
     private static final String RUNTIME_VERSION = "Unknown";

--- a/android/src/main/java/com/optimove/flutter/PushReceiver.java
+++ b/android/src/main/java/com/optimove/flutter/PushReceiver.java
@@ -23,7 +23,19 @@ public class PushReceiver extends PushBroadcastReceiver {
         super.onPushReceived(context, pushMessage);
         OptimoveFlutterPlugin.eventSink.send(new PushReceivedEvent(pushMessage).toMap(), false);
     }
-    
+
+    @Override
+    protected Intent getPushOpenActivityIntent(Context context, PushMessage pushMessage) {
+        Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
+
+        if (null == launchIntent) {
+            return null;
+        }
+
+        launchIntent.putExtra(PushMessage.EXTRAS_KEY, pushMessage);
+
+        return launchIntent;
+    }
     @Override
     protected void onPushOpened(Context context, PushMessage pushMessage) {
         try {

--- a/android/src/main/java/com/optimove/flutter/PushReceiver.java
+++ b/android/src/main/java/com/optimove/flutter/PushReceiver.java
@@ -9,44 +9,21 @@ import com.optimove.android.Optimove;
 import com.optimove.android.optimobile.Optimobile;
 import com.optimove.android.optimobile.PushBroadcastReceiver;
 import com.optimove.android.optimobile.PushMessage;
+import com.optimove.flutter.events.PushOpenedEvent;
+import com.optimove.flutter.events.PushReceivedEvent;
+
 import org.json.JSONException;
 import java.util.HashMap;
 import java.util.Map;
 
 public class PushReceiver extends PushBroadcastReceiver {
 
-    static Map<String, Object> pushMessageToMap(PushMessage pushMessage, String actionId) {
-        Map<String, Object> message = new HashMap<>(6);
-
-        try {
-            message.put("id", pushMessage.getId());
-            message.put("title", pushMessage.getTitle());
-            message.put("message", pushMessage.getMessage());
-            message.put("actionId", actionId);
-            message.put("data", JsonUtils.toMap(pushMessage.getData()));
-
-            if (null != pushMessage.getUrl()) {
-                message.put("url", pushMessage.getUrl().toString());
-            } else {
-                message.put("url", null);
-            }
-        } catch (JSONException e) {
-            e.printStackTrace();
-        }
-
-        return message;
-    }
-
     @Override
     protected void onPushReceived(Context context, PushMessage pushMessage) {
         super.onPushReceived(context, pushMessage);
-
-        Map<String, Object> event = new HashMap<>(2);
-        event.put("type", "push.received");
-        event.put("data", pushMessageToMap(pushMessage, null));
-        OptimoveFlutterPlugin.eventSink.send(event, false);
+        OptimoveFlutterPlugin.eventSink.send(new PushReceivedEvent(pushMessage).toMap(), false);
     }
-
+    
     @Override
     protected void onPushOpened(Context context, PushMessage pushMessage) {
         try {
@@ -106,9 +83,6 @@ public class PushReceiver extends PushBroadcastReceiver {
             context.startActivity(launchIntent);
         }
 
-        Map<String, Object> event = new HashMap<>(2);
-        event.put("type", "push.opened");
-        event.put("data", pushMessageToMap(pushMessage, actionId));
-        OptimoveFlutterPlugin.eventSinkDelayed.send(event);
+        OptimoveFlutterPlugin.eventSinkDelayed.send(new PushOpenedEvent(pushMessage).toMap(actionId));
     }
 }

--- a/android/src/main/java/com/optimove/flutter/events/PushEvent.java
+++ b/android/src/main/java/com/optimove/flutter/events/PushEvent.java
@@ -1,6 +1,7 @@
 package com.optimove.flutter.events;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.optimove.android.optimobile.PushMessage;
 import com.optimove.flutter.JsonUtils;
@@ -18,7 +19,7 @@ public abstract class PushEvent {
         this.pushMessage = pushMessage;
     }
 
-    protected Map<String, Object> pushMessageToMap(String actionId) {
+    protected Map<String, Object> pushMessageToMap(@Nullable String actionId) {
         Map<String, Object> message = new HashMap<>(6);
 
         try {

--- a/android/src/main/java/com/optimove/flutter/events/PushEvent.java
+++ b/android/src/main/java/com/optimove/flutter/events/PushEvent.java
@@ -1,0 +1,43 @@
+package com.optimove.flutter.events;
+
+import androidx.annotation.NonNull;
+
+import com.optimove.android.optimobile.PushMessage;
+import com.optimove.flutter.JsonUtils;
+
+import org.json.JSONException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class PushEvent {
+    @NonNull
+    private final PushMessage pushMessage;
+
+    protected PushEvent(@NonNull PushMessage pushMessage) {
+        this.pushMessage = pushMessage;
+    }
+
+    protected Map<String, Object> pushMessageToMap(String actionId) {
+        Map<String, Object> message = new HashMap<>(6);
+
+        try {
+            message.put("id", pushMessage.getId());
+            message.put("title", pushMessage.getTitle());
+            message.put("message", pushMessage.getMessage());
+            message.put("actionId", actionId);
+            message.put("data", JsonUtils.toMap(pushMessage.getData()));
+
+            if (null != pushMessage.getUrl()) {
+                message.put("url", pushMessage.getUrl().toString());
+            } else {
+                message.put("url", null);
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+
+        return message;
+    }
+
+}

--- a/android/src/main/java/com/optimove/flutter/events/PushOpenedEvent.java
+++ b/android/src/main/java/com/optimove/flutter/events/PushOpenedEvent.java
@@ -1,0 +1,24 @@
+package com.optimove.flutter.events;
+
+import androidx.annotation.NonNull;
+
+import com.optimove.android.optimobile.PushMessage;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PushOpenedEvent extends PushEvent {
+    public PushOpenedEvent(@NonNull PushMessage pushMessage) {
+        super(pushMessage);
+    }
+
+    public Map<String, Object> toMap(String actionId) {
+        Map<String, Object> event = new HashMap<>(2);
+        event.put("type", "push.opened");
+        event.put("data", pushMessageToMap(actionId));
+
+        return event;
+    }
+
+
+}

--- a/android/src/main/java/com/optimove/flutter/events/PushOpenedEvent.java
+++ b/android/src/main/java/com/optimove/flutter/events/PushOpenedEvent.java
@@ -1,6 +1,7 @@
 package com.optimove.flutter.events;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.optimove.android.optimobile.PushMessage;
 
@@ -12,7 +13,7 @@ public class PushOpenedEvent extends PushEvent {
         super(pushMessage);
     }
 
-    public Map<String, Object> toMap(String actionId) {
+    public Map<String, Object> toMap(@Nullable String actionId) {
         Map<String, Object> event = new HashMap<>(2);
         event.put("type", "push.opened");
         event.put("data", pushMessageToMap(actionId));

--- a/android/src/main/java/com/optimove/flutter/events/PushReceivedEvent.java
+++ b/android/src/main/java/com/optimove/flutter/events/PushReceivedEvent.java
@@ -1,0 +1,22 @@
+package com.optimove.flutter.events;
+
+import androidx.annotation.NonNull;
+
+import com.optimove.android.optimobile.PushMessage;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PushReceivedEvent extends PushEvent{
+
+    public PushReceivedEvent(@NonNull PushMessage pushMessage) {
+        super(pushMessage);
+    }
+
+    public Map<String, Object> toMap(){
+        Map<String, Object> event = new HashMap<>(2);
+        event.put("type", "push.received");
+        event.put("data", pushMessageToMap(null));
+        return event;
+    }
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: Optimove
 description: Demonstrates how to use the optimove_flutter plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-version: 2.2.0
+version: 3.0.0
 
 environment:
   sdk: ">=2.17.1 <3.0.0"

--- a/ios/Classes/SwiftOptimoveFlutterPlugin.swift
+++ b/ios/Classes/SwiftOptimoveFlutterPlugin.swift
@@ -15,7 +15,7 @@ public class SwiftOptimoveFlutterPlugin: NSObject, FlutterPlugin {
     private var eventSinkImmediate = QueueStreamHandler()
     private var eventSinkDelayed = QueueStreamHandler()
     
-    private let sdkVersion = "2.2.0"
+    private let sdkVersion = "3.0.0"
     private let sdkType = 105
     private let runtimeType = 9
     private let runtimeVersion = "Unknown";

--- a/ios/optimove_flutter.podspec
+++ b/ios/optimove_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'optimove_flutter'
-  s.version          = '2.2.0'
+  s.version          = '3.0.0'
   s.summary          = 'Optimove SDK Flutter plugin project.'
   s.description      = <<-DESC
 The Optimove SDK framework is used for reporting events and receive push notifications.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: optimove_flutter
-version: 2.2.0
+version: 3.0.0
 description: Optimove Flutter SDK
 homepage: https://www.optimove.com/
 repository: https://github.com/optimove-tech/Optimove-SDK-Flutter/


### PR DESCRIPTION
### Description of Changes

Currently, whenever a push notification is opened in Android, a new task is created.
Updated the launch intent flags for push notifications.

### Breaking Changes

-   For push opens don't set launch intent flags. Instead rely on the default launch mode

### Release Checklist

Bump versions in:

-   [x] `CHANGELOG.md`
-   [x] `pubspec.yaml` 
-   [x] `example/pubspec.yaml`
-   [x] `ios/optimove_flutter.podspec` 
-   [x] `ios/Classes/SwiftOptimoveFlutterPlugin.swift` 
-   [x] `android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java`

Release:

-   [ ] Squash and merge to main
-   [ ] Delete branch once merged
-   [ ] Create tag from main matching chosen version
-   [ ] Fill out release notes
-   [ ] Run `dart pub publish --dry-run` to make sure there are no issues
-   [ ] Run `dart pub publish`
