### PR TITLE
AB#265759 Fix in app deeplink listener gc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.2
+
+- Fixed Android in-app deep link handler being garbage collected by holding a strong reference
+
 ## 3.3.1
 
 - Updated the iOS SDK to version `~> 6.2.3`:

--- a/android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java
+++ b/android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java
@@ -16,6 +16,7 @@ import androidx.annotation.Nullable;
 import com.optimove.android.Optimove;
 import com.optimove.android.OptimoveConfig;
 import com.optimove.android.optimobile.DeferredDeepLinkHandlerInterface;
+import com.optimove.android.optimobile.InAppDeepLinkHandlerInterface;
 import com.optimove.android.optimobile.OptimoveInApp;
 
 import org.json.JSONException;
@@ -34,6 +35,8 @@ import static com.optimove.flutter.OptimoveFlutterPlugin.eventSinkDelayed;
 
 public class OptimoveInitProvider extends ContentProvider {
     private static final String TAG = OptimoveInitProvider.class.getName();
+    
+    private InAppDeepLinkHandlerInterface inAppDeepLinkHandler;
 
     private static final String OPTIMOVE_CREDENTIALS_KEY = "optimoveCredentials";
     private static final String OPTIMOBILE_CREDENTIALS_KEY = "optimobileCredentials";
@@ -234,22 +237,23 @@ public class OptimoveInitProvider extends ContentProvider {
                     eventSink.send(event);
                 });
 
-        OptimoveInApp.getInstance()
-                .setDeepLinkHandler((context, data) -> {
-                    Map<String, Object> event = new HashMap<>(2);
-                    Map<String, Object> eventData = new HashMap<>(3);
-                    event.put("type", "in-app.deepLinkPressed");
-                    eventData.put("messageId", data.getMessageId());
-                    try {
-                        eventData.put("deepLinkData", JsonUtils.toMap(data.getDeepLinkData()));
-                        eventData.put("messageData",
-                                data.getMessageData() != null ? JsonUtils.toMap(data.getMessageData()) : null);
-                    } catch (Throwable e) {
-                        e.printStackTrace();
-                    }
-                    event.put("data", eventData);
-                    eventSink.send(event);
-                });
+        inAppDeepLinkHandler = (context, data) -> {
+            Map<String, Object> event = new HashMap<>(2);
+            Map<String, Object> eventData = new HashMap<>(3);
+            event.put("type", "in-app.deepLinkPressed");
+            eventData.put("messageId", data.getMessageId());
+            try {
+                eventData.put("deepLinkData", JsonUtils.toMap(data.getDeepLinkData()));
+                eventData.put("messageData",
+                        data.getMessageData() != null ? JsonUtils.toMap(data.getMessageData()) : null);
+            } catch (Throwable e) {
+                e.printStackTrace();
+            }
+            event.put("data", eventData);
+            eventSink.send(event);
+        };
+        
+        OptimoveInApp.getInstance().setDeepLinkHandler(inAppDeepLinkHandler);
     }
 
     private void configureDeepLinking(@NonNull OptimoveConfig.Builder config, @Nullable String deepLinkingCname) {

--- a/android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java
+++ b/android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java
@@ -49,7 +49,7 @@ public class OptimoveInitProvider extends ContentProvider {
     private static final String IN_APP_DISPLAY_MODE_PAUSED = "paused";
     private static final String ENABLE_DDL_KEY = "enableDeferredDeepLinking";
 
-    private static final String SDK_VERSION = "3.3.1";
+    private static final String SDK_VERSION = "3.3.2";
     private static final int SDK_TYPE = 105;
     private static final int RUNTIME_TYPE = 9;
     private static final String RUNTIME_VERSION = "Unknown";

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <!-- Specify which URIs should be matched. Note, domain should be .lnk.click -->
-                <data android:scheme="https" android:host="optiflutter.lnk.click"/>
+                <data android:scheme="https" android:host="optiflutterqa.lnk.click"/>
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,20 +2,20 @@ PODS:
   - Flutter (1.0.0)
   - location (0.0.1):
     - Flutter
-  - optimove_flutter (3.3.0):
+  - optimove_flutter (3.3.1):
     - Flutter
-    - OptimoveCore (~> 6.2.0)
-    - OptimoveSDK (~> 6.2.0)
-  - OptimoveCore (6.2.0)
-  - OptimoveNotificationServiceExtension (6.2.0)
-  - OptimoveSDK (6.2.0):
-    - OptimoveCore (= 6.2.0)
+    - OptimoveCore (~> 6.2.3)
+    - OptimoveSDK (~> 6.2.3)
+  - OptimoveCore (6.2.3)
+  - OptimoveNotificationServiceExtension (6.2.3)
+  - OptimoveSDK (6.2.3):
+    - OptimoveCore (= 6.2.3)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - location (from `.symlinks/plugins/location/ios`)
   - optimove_flutter (from `.symlinks/plugins/optimove_flutter/ios`)
-  - OptimoveNotificationServiceExtension (~> 6.2.0)
+  - OptimoveNotificationServiceExtension (~> 6.2.3)
 
 SPEC REPOS:
   trunk:
@@ -33,12 +33,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  location: 3a2eed4dd2fab25e7b7baf2a9efefe82b512d740
-  optimove_flutter: 1381ad0fb21e1f89b7b2f065101711d7a4524554
-  OptimoveCore: 0031e0d2e3f5d05dc98079aeb10ed0417bb7094f
-  OptimoveNotificationServiceExtension: e98b38c8959a3c370b90f13702cd9376fbd5b6da
-  OptimoveSDK: 4934243689ab893e6eae126a79c71574dd62279a
+  location: 270786085f436c3740dcfa807d11b8b5a70f4425
+  optimove_flutter: 7208043392168a3c776795947beab6d92f871d35
+  OptimoveCore: 0ab3f615f0fd2e608359dd8a1a778f1e18296a5b
+  OptimoveNotificationServiceExtension: cc3fd3b2593298a6121cbf5e4d90025ef0a971a2
+  OptimoveSDK: fc4b8baf31a15ef8121c85dbc169bbfdc67d1c6a
 
-PODFILE CHECKSUM: b4b96110d1a9b4c828c389b6a002ecab3cd3640e
+PODFILE CHECKSUM: 731ccb105f4dcb3004a4a89021879e6571a9aa4e
 
 COCOAPODS: 1.16.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,14 +2,14 @@ PODS:
   - Flutter (1.0.0)
   - location (0.0.1):
     - Flutter
-  - optimove_flutter (3.3.1):
+  - optimove_flutter (3.3.2):
     - Flutter
     - OptimoveCore (~> 6.2.3)
     - OptimoveSDK (~> 6.2.3)
-  - OptimoveCore (6.2.3)
-  - OptimoveNotificationServiceExtension (6.2.3)
-  - OptimoveSDK (6.2.3):
-    - OptimoveCore (= 6.2.3)
+  - OptimoveCore (6.2.6)
+  - OptimoveNotificationServiceExtension (6.2.6)
+  - OptimoveSDK (6.2.6):
+    - OptimoveCore (= 6.2.6)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -34,10 +34,10 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   location: 270786085f436c3740dcfa807d11b8b5a70f4425
-  optimove_flutter: 7208043392168a3c776795947beab6d92f871d35
-  OptimoveCore: 0ab3f615f0fd2e608359dd8a1a778f1e18296a5b
-  OptimoveNotificationServiceExtension: cc3fd3b2593298a6121cbf5e4d90025ef0a971a2
-  OptimoveSDK: fc4b8baf31a15ef8121c85dbc169bbfdc67d1c6a
+  optimove_flutter: 228d12fcd955adbdd53b873862c75594ff2c188d
+  OptimoveCore: 4ef53a9d78098c24d57b0f83665cd54206aba40d
+  OptimoveNotificationServiceExtension: c34a2dda2c135366ceaecde695c310a8f7f4e4c9
+  OptimoveSDK: 0513296d50faa3cf5679c81b70563e322bc5fdd3
 
 PODFILE CHECKSUM: 731ccb105f4dcb3004a4a89021879e6571a9aa4e
 

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		5096D12B287CA67500CAF0B7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5096D134287CAF5000CAF0B7 /* NotificationServiceExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationServiceExtension.entitlements; sourceTree = "<group>"; };
 		50983BC828634FF70037A44E /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
+		584941902E6F27680031AC1A /* RunnerDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RunnerDebug.entitlements; sourceTree = "<group>"; };
 		5B489F891E60BED5CECBF7F9 /* Pods-NotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -160,6 +161,7 @@
 		97C146F01CF9000F007C117D /* Runner */ = {
 			isa = PBXGroup;
 			children = (
+				584941902E6F27680031AC1A /* RunnerDebug.entitlements */,
 				50983BC828634FF70037A44E /* Runner.entitlements */,
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
@@ -295,9 +297,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -729,7 +735,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
+				CODE_SIGN_ENTITLEMENTS = Runner/RunnerDebug.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = LDTF4M4FTC;
 				ENABLE_BITCODE = NO;

--- a/example/ios/Runner/RunnerDebug.entitlements
+++ b/example/ios/Runner/RunnerDebug.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:optiflutterqa.lnk.click</string>
+	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.optimove.flutter.optimove-sdk-flutter-example.optimove</string>
+	</array>
+</dict>
+</plist>

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -182,7 +182,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.3.0"
+    version: "3.3.2"
   path:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: Optimove
 description: Demonstrates how to use the optimove_flutter plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-version: 3.3.1
+version: 3.3.2
 
 environment:
   sdk: ">=2.17.1 <3.0.0"

--- a/ios/Classes/SwiftOptimoveFlutterPlugin.swift
+++ b/ios/Classes/SwiftOptimoveFlutterPlugin.swift
@@ -16,7 +16,7 @@ public class SwiftOptimoveFlutterPlugin: NSObject, FlutterPlugin {
     private var eventSinkImmediate = QueueStreamHandler()
     private var eventSinkDelayed = QueueStreamHandler()
     
-    private let sdkVersion = "3.3.1"
+    private let sdkVersion = "3.3.2"
     private let sdkType = 105
     private let runtimeType = 9
     private let runtimeVersion = "Unknown";

--- a/ios/optimove_flutter.podspec
+++ b/ios/optimove_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'optimove_flutter'
-  s.version          = '3.3.1'
+  s.version          = '3.3.2'
   s.summary          = 'Optimove SDK Flutter plugin project.'
   s.description      = <<-DESC
 The Optimove SDK framework is used for reporting events and receive push notifications.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: optimove_flutter
-version: 3.3.1
+version: 3.3.2
 description: Optimove Flutter SDK
 homepage: https://www.optimove.com/
 repository: https://github.com/optimove-tech/Optimove-SDK-Flutter/


### PR DESCRIPTION
# User description
### Description of Changes

The native Optimove Android SDK holds a **weak reference** to the in-app deep link handler. Our Flutter bridge was passing a lambda directly without storing it, causing the handler to be garbage collected and breaking in-app deep link event delivery to Flutter.

The solution is to store a strong reference to the `inAppDeepLinkHandler` as an instance field in `OptimoveInitProvider`.

### Breaking Changes

-   None

### Release Checklist

Bump versions in:

- [x] `CHANGELOG.md`
- [x] `pubspec.yaml` 
- [x] `example/pubspec.yaml`
- [x] `ios/optimove_flutter.podspec` 
- [x] `ios/Classes/SwiftOptimoveFlutterPlugin.swift` 
- [x] `android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java`

Release:

- [ ] Squash and merge to main
- [ ] Delete branch once merged
- [ ] Create tag from main matching chosen version
- [ ] Fill out release notes
- [ ] Run `dart pub publish --dry-run` to make sure there are no issues
- [ ] Run `dart pub publish`

---

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
OptimoveInitProvider_setAdditionalListeners_("OptimoveInitProvider.setAdditionalListeners"):::modified
OPTIMOVE_IN_APP_("OPTIMOVE_IN_APP"):::modified
OptimoveInitProvider_setAdditionalListeners_ -- "Refactored deep link handler to dedicated variable for event sending" --> OPTIMOVE_IN_APP_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Resolves an issue where the Android in-app deep link handler was prematurely garbage collected by storing a strong reference to the <code>InAppDeepLinkHandlerInterface</code> within the <code>OptimoveInitProvider</code> class. This ensures proper delivery of in-app deep link events from the Optimove Android SDK to the Flutter application.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/optimove-tech/Optimove-SDK-Flutter/15?tool=ast&topic=Update+Versions+%26+Config>Update Versions & Config</a>
        </td><td>Updates the SDK version to <code>3.3.2</code> across various configuration files and introduces new iOS entitlements for the example application to support associated domains for deep linking.<details><summary>Modified files (10)</summary><ul><li>pubspec.yaml</li>
<li>ios/optimove_flutter.podspec</li>
<li>ios/Classes/SwiftOptimoveFlutterPlugin.swift</li>
<li>example/pubspec.yaml</li>
<li>example/pubspec.lock</li>
<li>example/ios/Runner/RunnerDebug.entitlements</li>
<li>example/ios/Runner.xcodeproj/project.pbxproj</li>
<li>example/ios/Podfile.lock</li>
<li>example/android/app/src/main/AndroidManifest.xml</li>
<li>CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>konstantin_a@optimove.com</td><td>Updated-ios-version-to...</td><td>June 20, 2025</td></tr>
<tr><td>eli_g@optimove.com</td><td>build-2.2.0</td><td>October 29, 2023</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/optimove-tech/Optimove-SDK-Flutter/15?tool=ast&topic=Fix+Deep+Link+Handler>Fix Deep Link Handler</a>
        </td><td>Ensures the Android in-app deep link handler is not garbage collected by storing a strong reference to the <code>inAppDeepLinkHandler</code> instance in <code>OptimoveInitProvider</code>, allowing deep link events to be correctly delivered to Flutter.<details><summary>Modified files (1)</summary><ul><li>android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>konstantin_a@optimove.com</td><td>Updated-the-OptimoveIn...</td><td>June 20, 2025</td></tr>
<tr><td>eli_g@optimove.com</td><td>chore-update-version-i...</td><td>October 30, 2023</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/optimove-tech/Optimove-SDK-Flutter/15?tool=ast>(Baz)</a>.