### PR TITLE
AB#265340 - Fix Android ANR by moving method channel handler to background thread

### DIFF
--- a/android/src/main/java/com/optimove/flutter/OptimoveFlutterPlugin.java
+++ b/android/src/main/java/com/optimove/flutter/OptimoveFlutterPlugin.java
@@ -26,11 +26,13 @@ import java.util.TimeZone;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
+import io.flutter.plugin.common.StandardMethodCodec;
 
 /** OptimoveFlutterPlugin */
 public class OptimoveFlutterPlugin implements FlutterPlugin, MethodCallHandler, ActivityAware {
@@ -44,7 +46,9 @@ public class OptimoveFlutterPlugin implements FlutterPlugin, MethodCallHandler, 
 
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
-    methodChannel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "optimove_flutter_sdk");
+    BinaryMessenger messenger = flutterPluginBinding.getBinaryMessenger();
+    BinaryMessenger.TaskQueue taskQueue = messenger.makeBackgroundTaskQueue();
+    methodChannel = new MethodChannel(messenger, "optimove_flutter_sdk", StandardMethodCodec.INSTANCE, taskQueue);
     methodChannel.setMethodCallHandler(this);
 
     eventChannel = new EventChannel(flutterPluginBinding.getBinaryMessenger(), "optimove_flutter_sdk_events");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/optimove-tech/Optimove-SDK-Flutter/
 
 environment:
   sdk: ">=2.17.1 <3.0.0"
-  flutter: ">=2.5.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Use Flutter's makeBackgroundTaskQueue() to dispatch onMethodCall on a background thread instead of the main thread. This prevents ANRs caused by synchronous Optimove SDK calls (e.g. getInboxItems) that internally block on FutureTask.get() without a timeout.

Bumps minimum Flutter version to 3.0.0 for TaskQueue API support.

### Description of Changes

A customer reported ANRs on Android caused by synchronous in-app inbox method channel calls (getInboxItems, presentInboxMessage, deleteMessageFromInbox, markAsRead, markAllInboxItemsAsRead) blocking the main thread. The underlying Optimove Android SDK uses FutureTask.get() without a timeout, which can block for several seconds and trigger Android's ~5 second ANR threshold.

This change moves the Android MethodChannel handler to a background thread using Flutter's BinaryMessenger.makeBackgroundTaskQueue() API. All onMethodCall invocations now execute off the main thread, preventing ANRs while preserving identical behavior. The Optimove SDK internally handles posting UI work (e.g. in-app message presentation) to the main thread, so no methods require being called from the main thread.

### Breaking Changes

Minimum Flutter version bumped from >=2.5.0 to >=3.0.0 (required for the TaskQueue API; Flutter 3.0 was released May 2022)

### Release Checklist

Bump versions in:

- [ ] `CHANGELOG.md`
- [ ] `pubspec.yaml` 
- [ ] `example/pubspec.yaml`
- [ ] `ios/optimove_flutter.podspec` 
- [ ] `ios/Classes/SwiftOptimoveFlutterPlugin.swift` 
- [ ] `android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java`

Release:

- [ ] Squash and merge to main
- [ ] Delete branch once merged
- [ ] Create tag from main matching chosen version
- [ ] Fill out release notes
- [ ] Run `dart pub publish --dry-run` to make sure there are no issues
- [ ] Run `dart pub publish`
