### PR TITLE
AB#280512 - Android namespace APG8 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.4
+
+- Fixed Android build failure on AGP 7.4+/8.x by declaring the plugin's `namespace` in `android/build.gradle` and removing the deprecated `package` attribute from the Android manifest
+
 ## 3.3.3
 
 - Fixed ANR by moving blocking calls to a background thread on Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.3.4
 
-- Fixed Android build failure on AGP 7.4+/8.x by declaring the plugin's `namespace` in `android/build.gradle` and removing the deprecated `package` attribute from the Android manifest
+- Fixed Android build failure on AGP 8.x by declaring the plugin's `namespace` in `android/build.gradle`
 
 ## 3.3.3
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.optimove.flutter'
     compileSdkVersion 33
 
     compileOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.optimove.flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <application>
       <provider android:name=".OptimoveInitProvider"
           android:authorities="${applicationId}.optimoveinitprovider"

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.optimove.flutter">
   <application>
       <provider android:name=".OptimoveInitProvider"
           android:authorities="${applicationId}.optimoveinitprovider"

--- a/android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java
+++ b/android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java
@@ -49,7 +49,7 @@ public class OptimoveInitProvider extends ContentProvider {
     private static final String IN_APP_DISPLAY_MODE_PAUSED = "paused";
     private static final String ENABLE_DDL_KEY = "enableDeferredDeepLinking";
 
-    private static final String SDK_VERSION = "3.3.3";
+    private static final String SDK_VERSION = "3.3.4";
     private static final int SDK_TYPE = 105;
     private static final int RUNTIME_TYPE = 9;
     private static final String RUNTIME_VERSION = "Unknown";

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -15,18 +15,6 @@ allprojects {
         google()
         mavenCentral()
     }
-
-    subprojects {
-        afterEvaluate { project ->
-            if (project.hasProperty('android')) {
-                project.android {
-                    if (namespace == null) {
-                        namespace project.group
-                    }
-                }
-            }
-        }
-    }
 }
 
 rootProject.buildDir = '../build'

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -182,7 +182,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.3.2"
+    version: "3.3.4"
   path:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: Optimove
 description: Demonstrates how to use the optimove_flutter plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-version: 3.3.3
+version: 3.3.4
 
 environment:
   sdk: ">=2.17.1 <3.0.0"

--- a/ios/Classes/SwiftOptimoveFlutterPlugin.swift
+++ b/ios/Classes/SwiftOptimoveFlutterPlugin.swift
@@ -16,7 +16,7 @@ public class SwiftOptimoveFlutterPlugin: NSObject, FlutterPlugin {
     private var eventSinkImmediate = QueueStreamHandler()
     private var eventSinkDelayed = QueueStreamHandler()
     
-    private let sdkVersion = "3.3.3"
+    private let sdkVersion = "3.3.4"
     private let sdkType = 105
     private let runtimeType = 9
     private let runtimeVersion = "Unknown";

--- a/ios/optimove_flutter.podspec
+++ b/ios/optimove_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'optimove_flutter'
-  s.version          = '3.3.3'
+  s.version          = '3.3.4'
   s.summary          = 'Optimove SDK Flutter plugin project.'
   s.description      = <<-DESC
 The Optimove SDK framework is used for reporting events and receive push notifications.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: optimove_flutter
-version: 3.3.3
+version: 3.3.4
 description: Optimove Flutter SDK
 homepage: https://www.optimove.com/
 repository: https://github.com/optimove-tech/Optimove-SDK-Flutter/


### PR DESCRIPTION
Modern AGP requires library modules to declare their namespace in build.gradle rather than via the AndroidManifest package attribute, otherwise the plugin fails to configure with "Namespace not specified" on AGP 8.x. Adds namespace to android/build.gradle, removes the now deprecated package attribute from the manifest.

### Description of Changes

- `android/build.gradle`: declared `namespace 'com.optimove.flutter'` inside the `android { }` block (the `namespace` DSL is supported since AGP 4.2, so this is safe across all AGP versions used by any currently supported Flutter release).
- `android/src/main/AndroidManifest.xml`: removed the now-deprecated `package="com.optimove.flutter"` attribute (keeping it would be a hard error on AGP 8+). 

### Breaking Changes

-   None

### Release Checklist

Bump versions in:

- [ ] `CHANGELOG.md`
- [ ] `pubspec.yaml` 
- [ ] `example/pubspec.yaml`
- [ ] `ios/optimove_flutter.podspec` 
- [ ] `ios/Classes/SwiftOptimoveFlutterPlugin.swift` 
- [ ] `android/src/main/java/com/optimove/flutter/OptimoveInitProvider.java`

Release:

- [ ] Squash and merge to main
- [ ] Delete branch once merged
- [ ] Create tag from main matching chosen version
- [ ] Fill out release notes
- [ ] Run `dart pub publish --dry-run` to make sure there are no issues
- [ ] Run `dart pub publish`
